### PR TITLE
Fixed Feb 29th being considered as invalid

### DIFF
--- a/date.cpp
+++ b/date.cpp
@@ -140,9 +140,11 @@ STime::STime(const tm *time)
     second = time->tm_sec;
     millisecond = 0;
 
+    const int* monthLengthsThisYear = (isLeap(year) ? MONTH_LENGTHS_LEAP : MONTH_LENGTHS);
+
     valid = year >= TM_START_YEAR
       && day > 0
-      && day <= MONTH_LENGTHS[month]
+      && day <= monthLengthsThisYear[month]
       && hour >= 0
       && minute >= 0
       && second >= 0;


### PR DESCRIPTION
Hi !
The `const tm*` constuctor of `Stime` had a bug, it considered February 29th as invalid even in leap years.